### PR TITLE
Remove result codes from error codes

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -2923,7 +2923,7 @@ static void dbsqliteStripCaseDiacritics(sqlite3_context *context, int argc, cons
 
 - (NSError *)databaseError {
     int code = sqlite3_errcode(database);
-    if (code) {
+    if (code && code != SQLITE_DONE && code != SQLITE_OK && code != SQLITE_ROW) {
         NSDictionary *userInfo = @{
                                    EncryptedStoreErrorMessageKey : [NSString stringWithUTF8String:sqlite3_errmsg(database)]
                                    };


### PR DESCRIPTION
Avoid using the result codes as error codes.

More info: https://www.sqlite.org/rescode.html:
_"Error codes" are a subset of "result codes" that indicate that something has gone wrong. There are only a few non-error result codes: [SQLITE_OK](https://www.sqlite.org/rescode.html#ok), [SQLITE_ROW](https://www.sqlite.org/rescode.html#row), and [SQLITE_DONE](https://www.sqlite.org/rescode.html#done). The term "error code" means any result code other than these three._